### PR TITLE
fix: Error 500 

### DIFF
--- a/curl_helper.php
+++ b/curl_helper.php
@@ -2,7 +2,7 @@
 
 // User agent to use for the cURL request.
 // This is a common user agent that should be accepted by most servers.
-define('CURL_USERAGENT', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36');
+define('CURL_USERAGENT', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36');
 
 /**
  * Fetch data from a URL with optional limits.


### PR DESCRIPTION
> This is the error I get in Safari when I use the URL
> Error: Unable to fetch URL. HTTP 500, cURL error: The requested URL returned error: 500 

 _Originally posted by @gferreroferri in [#22](https://github.com/bressanmarcos/ICS-Timezone-Fixer/issues/22#issuecomment-3210376818)_

Changes
---

- Change UserAgent to one that works